### PR TITLE
Deleted unnecessary explicit hiding of back button

### DIFF
--- a/Src/MoneyManager.Windows/AppShell.xaml.cs
+++ b/Src/MoneyManager.Windows/AppShell.xaml.cs
@@ -76,13 +76,6 @@ namespace MoneyManager.Windows
 
             var currentView = SystemNavigationManager.GetForCurrentView();
             currentView.BackRequested += SystemNavigationManager_BackRequested;
-
-            // If on a phone device that has hardware buttons then we hide the app's back button.
-            currentView.AppViewBackButtonVisibility =
-                ApiInformation.IsTypePresent("Windows.Phone.UI.Input.HardwareButtons")
-                    ? AppViewBackButtonVisibility.Collapsed
-                    : AppViewBackButtonVisibility.Visible;
-
             NavMenuList.ItemsSource = navlist;
         }
 


### PR DESCRIPTION
Back button does not need to be explicitly hidden for tablet mode and phones as it done automatically.