### PR TITLE
Seperated splitview pane to top and bottom parts

### DIFF
--- a/Src/MoneyManager.Windows/AppShell.xaml
+++ b/Src/MoneyManager.Windows/AppShell.xaml
@@ -63,17 +63,31 @@
         <customControls:SwipeableSplitView x:Name="RootSplitView"
                                            DisplayMode="Inline"
                                            OpenPaneLength="256"
-                                           IsTabStop="False">
+                                           IsTabStop="False"
+                                           IsPanSelectorEnabled="False">
             <customControls:SwipeableSplitView.Pane>
-                <!-- A custom ListView to display the items in the pane.  The automation Name is set in the ContainerContentChanging event. -->
-                <customControls:NavMenuListView x:Name="NavMenuList"
+                <Grid>
+                    <!-- A custom ListView to display the items in the pane.  The automation Name is set in the ContainerContentChanging event. -->
+                    <customControls:NavMenuListView x:Name="NavMenuListTop"
+                                                VerticalAlignment="Top"
                                                 TabIndex="3"
                                                 Margin="0,48,0,0"
                                                 ContainerContentChanging="NavMenuItemContainerContentChanging"
                                                 ItemContainerStyle="{StaticResource NavMenuItemContainerStyle}"
                                                 ItemTemplate="{StaticResource NavMenuItemTemplate}"
                                                 ItemInvoked="NavMenuList_ItemInvoked" />
+                    <!-- A buttom section to seperate common functions with uncommon -->
+                    <customControls:NavMenuListView x:Name="NavMenuListBottom"
+                                                VerticalAlignment="Bottom"
+                                                TabIndex="3"
+                                                Margin="0,48,0,0"
+                                                ContainerContentChanging="NavMenuItemContainerContentChanging"
+                                                ItemContainerStyle="{StaticResource NavMenuItemContainerStyle}"
+                                                ItemTemplate="{StaticResource NavMenuItemTemplate}"
+                                                ItemInvoked="NavMenuList_ItemInvoked" />
+                </Grid>
             </customControls:SwipeableSplitView.Pane>
+            
             <customControls:SwipeableSplitView.Content>
                 <Frame x:Name="Frame"
                        Navigating="OnNavigatingToPage"
@@ -89,7 +103,6 @@
                     </Frame.ContentTransitions>
                 </Frame>
             </customControls:SwipeableSplitView.Content>
-
         </customControls:SwipeableSplitView>
 
         <!-- Declared last to have it rendered above everything else, but it needs to be the first item in the tab sequence. -->

--- a/Src/MoneyManager.Windows/Views/MainView.xaml
+++ b/Src/MoneyManager.Windows/Views/MainView.xaml
@@ -16,8 +16,28 @@
         </core:EventTriggerBehavior>
     </interactivity:Interaction.Behaviors>
 
-    <Page.BottomAppBar>
-        <CommandBar>
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <basicControls:PageHeader>
+            <basicControls:PageHeader.HeaderContent>
+                <TextBlock Style="{ThemeResource PageTitleTextBlockStyle}" Text="Accounts"
+                           x:Uid="AccountTitle" />
+            </basicControls:PageHeader.HeaderContent>
+        </basicControls:PageHeader>
+
+        <Grid Grid.Row="1"
+              Margin="0,9.5,0,0"
+              EntranceNavigationTransitionInfo.IsTargetElement="True">
+            <controls:AccountListUserControl VerticalAlignment="Stretch" />
+        </Grid>
+
+        <CommandBar Grid.Row="2">
             <CommandBar.PrimaryCommands>
                 <AppBarButton Icon="Add"
                               x:Uid="AddIncomeLabel"
@@ -42,26 +62,5 @@
                               Command="{Binding GoToAddAccountCommand}" />
             </CommandBar.SecondaryCommands>
         </CommandBar>
-    </Page.BottomAppBar>
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-
-        <basicControls:PageHeader>
-            <basicControls:PageHeader.HeaderContent>
-                <TextBlock Style="{ThemeResource PageTitleTextBlockStyle}" Text="Accounts"
-                           x:Uid="AccountTitle" />
-            </basicControls:PageHeader.HeaderContent>
-        </basicControls:PageHeader>
-
-        <Grid Grid.Row="1"
-              Margin="0,9.5,0,0"
-              EntranceNavigationTransitionInfo.IsTargetElement="True">
-            <controls:AccountListUserControl VerticalAlignment="Stretch" />
-        </Grid>
-
     </Grid>
 </Page>

--- a/Src/MoneyManager.Windows/Views/SettingsView.xaml
+++ b/Src/MoneyManager.Windows/Views/SettingsView.xaml
@@ -9,21 +9,11 @@
     DataContext="{Binding SettingDefaultsView, Source={StaticResource CoreModule}}"
     mc:Ignorable="d">
 
-    <Page.BottomAppBar>
-        <CommandBar ClosedDisplayMode="Minimal">
-            <CommandBar.SecondaryCommands>
-                <AppBarButton Icon="Add"
-                              Label="New Category"
-                              x:Uid="AddCategoryLabel"
-                              Click="AddCategory" />
-            </CommandBar.SecondaryCommands>
-        </CommandBar>
-    </Page.BottomAppBar>
-
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid Grid.Row="1">
             <Pivot Style="{StaticResource TabsStylePivotStyle}">
@@ -58,5 +48,13 @@
                 </PivotItem>
             </Pivot>
         </Grid>
+        <CommandBar Grid.Row="2" ClosedDisplayMode="Minimal">
+            <CommandBar.SecondaryCommands>
+                <AppBarButton Icon="Add"
+                              Label="New Category"
+                              x:Uid="AddCategoryLabel"
+                              Click="AddCategory" />
+            </CommandBar.SecondaryCommands>
+        </CommandBar>
     </Grid>
 </Page>

--- a/Src/MoneyManager.Windows/Views/StatisticsView.xaml
+++ b/Src/MoneyManager.Windows/Views/StatisticsView.xaml
@@ -9,18 +9,11 @@
       DataContext="{Binding StatisticView, Source={StaticResource CoreModule}}"
       mc:Ignorable="d">
 
-    <Page.BottomAppBar>
-        <CommandBar>
-            <CommandBar.SecondaryCommands>
-                <AppBarButton Icon="Calendar"
-                              x:Uid="SetDate"
-                              Label="Set Date"
-                              Click="SetDate" />
-            </CommandBar.SecondaryCommands>
-        </CommandBar>
-    </Page.BottomAppBar>
-
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
         <Pivot Style="{StaticResource TabsStylePivotStyle}">
             <PivotItem>
                 <PivotItem.Header>
@@ -60,5 +53,13 @@
                 </Grid>
             </PivotItem>
         </Pivot>
+        <CommandBar Grid.Row="1" ClosedDisplayMode="Minimal">
+            <CommandBar.SecondaryCommands>
+                <AppBarButton Icon="Calendar"
+                              x:Uid="SetDate"
+                              Label="Set Date"
+                              Click="SetDate" />
+            </CommandBar.SecondaryCommands>
+        </CommandBar>
     </Grid>
 </Page>


### PR DESCRIPTION
The splitview pane is now made of two listviews, top and bottom. Code had to be reworked to support having two listviews. Command bars have been moved from root page to their own grid row so that they no longer go over the splitview. #618